### PR TITLE
resolve compile problem on linux

### DIFF
--- a/src/DistanceMap.hpp
+++ b/src/DistanceMap.hpp
@@ -74,7 +74,7 @@ class DistanceMap
 
 public:
 
-    DistanceMap::DistanceMap()
+    DistanceMap()
     {
         m_stack.reserve(128*128);
     }
@@ -88,7 +88,7 @@ public:
         compute(map, gx, gy);
     }
 
-    void DistanceMap::compute(const StarDraftMap & map, size_t gx, size_t gy)
+    void compute(const StarDraftMap & map, size_t gx, size_t gy)
     {
         m_gx  = gx;
         m_gy  = gy;
@@ -114,7 +114,7 @@ public:
         return count;
     }
 
-    Tile DistanceMap::getDirection(size_t x, size_t y, size_t index) const
+    Tile getDirection(size_t x, size_t y, size_t index) const
     {
         unsigned char dirs = m_directions.get(x, y);
 


### PR DESCRIPTION
this error:
```shell
g++ -c -O3 -std=c++17 -I./src src/GameEngine.cpp -o src/GameEngine.o
In file included from src/GameState_Map.h:6,
                 from src/GameEngine.cpp:5:
src/DistanceMap.hpp:77:5: error: extra qualification ‘DistanceMap::’ on member ‘DistanceMap’ [-fpermissive]
   77 |     DistanceMap::DistanceMap()
      |     ^~~~~~~~~~~
src/DistanceMap.hpp:91:10: error: extra qualification ‘DistanceMap::’ on member ‘compute’ [-fpermissive]
   91 |     void DistanceMap::compute(const `StarDraftMap` & map, size_t gx, size_t gy)
      |          ^~~~~~~~~~~
src/DistanceMap.hpp:117:10: error: extra qualification ‘DistanceMap::’ on member ‘getDirection’ [-fpermissive]
  117 |     Tile DistanceMap::getDirection(size_t x, size_t y, size_t index) const
      |          ^~~~~~~~~~~
make: *** [Makefile:37 : src/GameEngine.o] Erreur 1
```